### PR TITLE
Finalize 2.0.1 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.1 (Unreleased)
+## 2.0.1 (2026-08-25)
 
 ### Maintenance
 


### PR DESCRIPTION
## Summary

- replace the 2.0.1 changelog `Unreleased` marker with the release date
- establish the exact commit that may be published and tagged as `v2.0.1`

## Verification

- synchronized Cargo, lockfile, and MCPB versions: `2.0.1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked`
- `cargo build --release --locked`
- `cargo deny check`
- `dist plan` announces `v2.0.1`
- `cargo publish --dry-run --locked`
- `git diff --check`

The real crate publication and tag-triggered GitHub Release will occur only after this exact change is approved and merged.