### PR TITLE
chore: prepare 2.0.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,8 @@ jobs:
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-          RELEASE_TITLE="${RELEASE_TAG#v}"
+          RELEASE_TITLE="${RELEASE_TAG##*/}"
+          RELEASE_TITLE="${RELEASE_TITLE#v}"
 
           gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$RELEASE_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,11 +315,15 @@ jobs:
           RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
         run: |
           # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
           RELEASE_TITLE="${RELEASE_TAG##*/}"
           RELEASE_TITLE="${RELEASE_TITLE#v}"
 
-          gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$RELEASE_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          release_flags=()
+          if [[ -n "$PRERELEASE_FLAG" ]]; then
+            release_flags+=("$PRERELEASE_FLAG")
+          fi
+          gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" "${release_flags[@]}" --title "$RELEASE_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   announce:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,14 +310,15 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          RELEASE_TITLE="${RELEASE_TAG#v}"
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$RELEASE_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   announce:
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,6 @@ Each native CI job builds and validates an MCPB 0.3 bundle. Release automation i
 - Keep the version synchronized in `Cargo.toml`, the root `tiingo-mcp` entry in `Cargo.lock`, and `packaging/mcpb/manifest.json`.
 - Add the matching `CHANGELOG.md` section as `X.Y.Z (Unreleased)` while changes are accumulating.
 - Before creating the release tag, replace `Unreleased` with the release date for changelog history.
-- Keep the GitHub Release title derived from the tag without its leading `v` so the webpage shows only `X.Y.Z`, with no date or timestamp.
+- Keep the GitHub Release title derived from the tag without a supported namespace or leading `v` so the webpage shows only `X.Y.Z`, with no date or timestamp.
 - Keep current-release URLs in `README.md` pointed at the latest published tag until the replacement release exists.
 - Run the full verification set plus `dist plan` and `cargo publish --dry-run --locked` before requesting release authorization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Each native CI job builds and validates an MCPB 0.3 bundle. Release automation i
 
 - Keep the version synchronized in `Cargo.toml`, the root `tiingo-mcp` entry in `Cargo.lock`, and `packaging/mcpb/manifest.json`.
 - Add the matching `CHANGELOG.md` section as `X.Y.Z (Unreleased)` while changes are accumulating.
-- Before creating the release tag, replace `Unreleased` with the release date. cargo-dist uses that heading for the GitHub Release title; tagging first will publish an incorrect `(Unreleased)` title.
+- Before creating the release tag, replace `Unreleased` with the release date for changelog history.
+- Keep the GitHub Release title derived from the tag without its leading `v` so the webpage shows only `X.Y.Z`, with no date or timestamp.
 - Keep current-release URLs in `README.md` pointed at the latest published tag until the replacement release exists.
 - Run the full verification set plus `dist plan` and `cargo publish --dry-run --locked` before requesting release authorization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.2 (2026-08-25)
+
+### Dependencies
+
+- Updated `actions/checkout` and `actions/upload-artifact` to their current major versions.
+- Updated `rand` from 0.9 to 0.10 and removed the superseded transitive dependency versions.
+
+### Testing
+
+- Raised overall line coverage from 84.79% to 93.25% and added a 93% stable-CI floor.
+- Added end-to-end route, query, text, and structured-response checks for all 17 MCP tools, bringing the MCP tool layer to 100% line coverage.
+- Added deterministic MCP consistency and latency checks plus an ignored, one-request live EOD accuracy check.
+- Enforced Cargo offline mode for the MSRV and stable test suites after dependency installation.
+
 ## 2.0.1 (2026-08-25)
 
 ### Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "tiingo-mcp"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiingo-mcp"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for the Tiingo financial data API"

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "tiingo-mcp",
   "display_name": "Tiingo MCP",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Stocks, forex, crypto, news, fundamentals, and corporate actions from Tiingo.",
   "author": { "name": "Major7" },
   "repository": { "type": "git", "url": "https://github.com/major7apps/tiingo-mcp" },


### PR DESCRIPTION
## Summary

- bump the crate, lockfile root package, and MCPB manifest to 2.0.2
- document the dependency updates and expanded MCP quality/coverage evidence
- derive the GitHub Release webpage title from the tag without its leading v, producing exactly 2.0.2 with no date or timestamp
- update the repository release guidance to preserve that title contract

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- CARGO_NET_OFFLINE=true cargo test --all-targets --all-features --locked: 45 passed, 2 intentionally ignored live tests
- CARGO_NET_OFFLINE=true cargo llvm-cov --all-targets --all-features --locked --fail-under-lines 93 --summary-only: 93.25% lines
- cargo build --release --locked
- cargo deny check
- cargo run --quiet --locked -- --version: tiingo-mcp 2.0.2
- dist plan: v2.0.2 and all five native targets
- cargo publish --dry-run --locked: package verification passed; upload aborted as expected
- release-title shell expansion: v2.0.2 becomes 2.0.2
- CodeRabbit CLI: 0 issues
