### PR TITLE
Prepare tiingo-mcp 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.1.0 (Unreleased)
 
 ### API surface
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "tiingo-mcp"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiingo-mcp"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for the Tiingo financial data API"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/major7apps/tiingo-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/major7apps/tiingo-mcp/actions/workflows/ci.yml)
 
-A native [Model Context Protocol](https://modelcontextprotocol.io) server for the [Tiingo](https://www.tiingo.com) financial data API. The unreleased development tree exposes 38 tools across EOD, IEX, consolidated equity, BOATS, forex, crypto, Crypto Yield, funds, Search, news, fundamentals, corporate actions, and bounded upstream market-data subscriptions, plus three fixed resources, one resource template, and five prompts.
+A native [Model Context Protocol](https://modelcontextprotocol.io) server for the [Tiingo](https://www.tiingo.com) financial data API. The unreleased development tree exposes 38 tools across EOD, IEX, consolidated equity, BOATS, forex, crypto, Crypto Yield, funds, Search, news, fundamentals, corporate actions, and bounded upstream market-data subscriptions, plus three fixed resources, one resource template, and five prompts. This surface is being prepared as version 2.1.0.
 
 The server uses MCP over stdio. Its finite subscription tools connect to upstream Tiingo WebSockets; MCP Streamable HTTP and WebSocket transports are not part of this server.
 
 ## Installation
 
-Published 2.0.2 installers and the crates.io package expose the released 17-tool surface. The expanded 38-tool surface documented below is Unreleased and requires building this development branch from source; the release URLs remain pinned to the latest published tag.
+Published 2.0.2 installers and the crates.io package expose the released 17-tool surface. Version 2.1.0 is in release preparation with the expanded 38-tool surface documented below; until it is published, build this branch from source to use that surface. Release URLs remain pinned to the latest published tag.
 
 ### Release installer
 
@@ -29,10 +29,16 @@ The installers place `tiingo-mcp` in Cargo's binary directory. Ensure that direc
 
 ### Cargo
 
-With Rust 1.88 or newer installed:
+With Rust 1.88 or newer installed, install the latest published release:
 
 ```bash
-cargo install tiingo-mcp --locked
+cargo install tiingo-mcp --version 2.0.2 --locked
+```
+
+To install the unreleased 2.1.0 release-preparation tree from a local checkout:
+
+```bash
+cargo install --path . --locked
 ```
 
 ### MCPB desktop bundle
@@ -81,7 +87,7 @@ TIINGO_API_KEY=your-api-key-here tiingo-mcp
 
 ## Tools
 
-This is the Unreleased 38-tool development surface. The original 17 tool names, required inputs, omission behavior, and results remain compatible; four optional `columns` fields are the only approved additions to those legacy descriptors.
+This is the 2.1.0 release-preparation 38-tool surface. The original 17 tool names, required inputs, omission behavior, and results remain compatible; four optional `columns` fields are the only approved additions to those legacy descriptors.
 
 ### Stocks (EOD and lifecycle metadata)
 

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "tiingo-mcp",
   "display_name": "Tiingo MCP",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Stocks, forex, crypto, news, fundamentals, and corporate actions from Tiingo.",
   "author": { "name": "Major7" },
   "repository": { "type": "git", "url": "https://github.com/major7apps/tiingo-mcp" },


### PR DESCRIPTION
## Summary

- prepare the backward-compatible 38-tool REST/upstream-WebSocket expansion as semantic version 2.1.0
- synchronize `Cargo.toml`, the root `Cargo.lock` package, and the MCPB manifest, and convert the changelog to `2.1.0 (Unreleased)`
- clarify that 2.0.2 remains the published registry/installer release while local source installs exercise the unreleased 2.1.0 tree; keep installer URLs pinned to `v2.0.2`

## Verification

- `cargo +stable fmt --check`
- strict Clippy on stable 1.98.0 and Rust 1.88.0
- full locked offline suite on both toolchains: 184 passed, 12 authorized-live tests ignored
- `cargo +stable llvm-cov --all-targets --all-features --locked --fail-under-lines 93 --summary-only`: 93.95% lines
- stable and Rust 1.88.0 locked release builds
- `cargo deny check all`
- `dist plan` for all five release targets
- `cargo +stable publish --dry-run --locked`
- focused RMCP contract/tools/resources/prompts and stdio process tests
- local Apple Silicon MCPB 2.1.2 validation, pack, and inspection
- CodeRabbit CLI rereview: 0 issues

Ignored live tests were not run; they remain separately authorized and quota-consuming.

## Release stop

This PR does not tag, publish the crate, upload MCPB bundles, or create a GitHub release. Those actions remain separately authorized.
