### PR TITLE
docs: date 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.0 (Unreleased)
+## 2.1.0 (2026-08-26)
 
 ### API surface
 


### PR DESCRIPTION
## Summary

- replace the authorized 2.1.0 Unreleased marker with the 2026-08-26 release date
- preserve the bare GitHub release title and existing version synchronization
- leave installer URLs on the currently published 2.0.2 until 2.1.0 exists

## Verification

- cargo fmt --check
- strict Clippy on stable and Rust 1.88.0
- full locked offline suite on stable and Rust 1.88.0: 184 passed, 12 ignored per toolchain
- cargo llvm-cov: 93.92% lines, floor 93%
- release builds on stable and Rust 1.88.0
- cargo deny check all
- dist plan
- cargo publish --dry-run --locked
- CodeRabbit CLI review completed; its sole request to retain Unreleased was rejected because release authorization is explicit and AGENTS.md requires dating before tagging

No quota-consuming live tests were run.